### PR TITLE
Add rounded corner

### DIFF
--- a/CPU Per Core Graph.ini
+++ b/CPU Per Core Graph.ini
@@ -7,13 +7,13 @@ Name=CPU Usage Per-Core Graph
 Author=ChatGPT4+QinnShou
 Information=Displays CPU usage for each of logical processors as a graph
 License=Creative Commons Attribution-Non-Commercial-Share Alike 3.0
-Version=1.0
+Version=1.1
 
 [Variables]
 GraphW=50
 GraphH=50
-GraphWPad=5
-GraphHPad=5
+GraphWPad=6
+GraphHPad=6
 MeterValue=Histogram
 ;antialias
 AntiAliasValue=1
@@ -37,9 +37,13 @@ ESR=50
 ESG=80
 ESB=50
 ESA=120
+; Rounded rectangle wrapper
+; ShapeValue=Rectangle [Relative X][Relative Y][Width][Height][Cornor radius X][Cornor radius Y]
+; If you do not like it simply change them to zero
+ShapeValue=Rectangle 0,0,#GraphW#,#GraphH#,8,8
 
 ; Measures for each CPU core
-; To change graph to E-core coloring, manually update [CPU0Graph] to use #ESR instead of #SR color variable
+; To change graph to E-core (Efficient-Core) coloring, manually update [CPU0Graph] to use #ESR instead of #SR color variable
 
 [MeasureCPU0]
 Measure=CPU
@@ -140,264 +144,395 @@ Processor=24
 [CPU0Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU0
-X=((1*#GraphWPad#)+(0*#GraphW#))
-Y=((1*#GraphHPad#)+(0*#GraphH#))
-Y=1*#GraphHPad#+0*#GraphH#
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU0GraphWrapper
 
 [CPU1Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU1
-X=((2*#GraphWPad#)+(1*#GraphW#))
-Y=((1*#GraphHPad#)+(0*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU1GraphWrapper
 
 [CPU2Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU2
-X=((3*#GraphWPad#)+(2*#GraphW#))
-Y=((1*#GraphHPad#)+(0*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU2GraphWrapper
 
 [CPU3Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU3
-X=((4*#GraphWPad#)+(3*#GraphW#))
-Y=((1*#GraphHPad#)+(0*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU3GraphWrapper
 
 [CPU4Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU4
-X=((5*#GraphWPad#)+(4*#GraphW#))
-Y=((1*#GraphHPad#)+(0*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU4GraphWrapper
 
 [CPU5Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU5
-X=((6*#GraphWPad#)+(5*#GraphW#))
-Y=((1*#GraphHPad#)+(0*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU5GraphWrapper
 
 [CPU6Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU6
-X=((1*#GraphWPad#)+(0*#GraphW#))
-Y=((2*#GraphHPad#)+(1*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU6GraphWrapper
 
 [CPU7Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU7
-X=((2*#GraphWPad#)+(1*#GraphW#))
-Y=((2*#GraphHPad#)+(1*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU7GraphWrapper
 
 [CPU8Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU8
-X=((3*#GraphWPad#)+(2*#GraphW#))
-Y=((2*#GraphHPad#)+(1*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU8GraphWrapper
 
 [CPU9Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU9
-X=((4*#GraphWPad#)+(3*#GraphW#))
-Y=((2*#GraphHPad#)+(1*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU9GraphWrapper
 
 [CPU10Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU10
-X=((5*#GraphWPad#)+(4*#GraphW#))
-Y=((2*#GraphHPad#)+(1*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU10GraphWrapper
 
 [CPU11Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU11
-X=((6*#GraphWPad#)+(5*#GraphW#))
-Y=((2*#GraphHPad#)+(1*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU11GraphWrapper
 
 [CPU12Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU12
-X=((1*#GraphWPad#)+(0*#GraphW#))
-Y=((3*#GraphHPad#)+(2*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU12GraphWrapper
 
 [CPU13Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU13
-X=((2*#GraphWPad#)+(1*#GraphW#))
-Y=((3*#GraphHPad#)+(2*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU13GraphWrapper
 
 [CPU14Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU14
-X=((3*#GraphWPad#)+(2*#GraphW#))
-Y=((3*#GraphHPad#)+(2*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU14GraphWrapper
 
 [CPU15Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU15
-X=((4*#GraphWPad#)+(3*#GraphW#))
-Y=((3*#GraphHPad#)+(2*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#LR#,#LG#,#LB#,#LA#
 SolidColor=#SR#,#SG#,#SB#,#SA#
 AntiAlias=#AntiAliasValue#
+Container=CPU15GraphWrapper
 
 [CPU16Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU16
-X=((5*#GraphWPad#)+(4*#GraphW#))
-Y=((3*#GraphHPad#)+(2*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU16GraphWrapper
 
 [CPU17Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU17
-X=((6*#GraphWPad#)+(5*#GraphW#))
-Y=((3*#GraphHPad#)+(2*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU17GraphWrapper
 
 [CPU18Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU18
-X=((1*#GraphWPad#)+(0*#GraphW#))
-Y=((4*#GraphHPad#)+(3*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU18GraphWrapper
 
 [CPU19Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU19
-X=((2*#GraphWPad#)+(1*#GraphW#))
-Y=((4*#GraphHPad#)+(3*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU19GraphWrapper
 
 [CPU20Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU20
-X=((3*#GraphWPad#)+(2*#GraphW#))
-Y=((4*#GraphHPad#)+(3*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU20GraphWrapper
 
 [CPU21Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU21
-X=((4*#GraphWPad#)+(3*#GraphW#))
-Y=((4*#GraphHPad#)+(3*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU21GraphWrapper
 
 [CPU22Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU22
-X=((5*#GraphWPad#)+(4*#GraphW#))
-Y=((4*#GraphHPad#)+(3*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU22GraphWrapper
 
 [CPU23Graph]
 Meter=#MeterValue#
 MeasureName=MeasureCPU23
-X=((6*#GraphWPad#)+(5*#GraphW#))
-Y=((4*#GraphHPad#)+(3*#GraphH#))
 W=#GraphW#
 H=#GraphH#
 PrimaryColor=#ELR#,#ELG#,#ELB#,#ELA#
 SolidColor=#ESR#,#ESG#,#ESB#,#ESA#
 AntiAlias=#AntiAliasValue#
+Container=CPU23GraphWrapper
+
+[CPU0GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=Rectangle 0,0,100,100,8,8
+X=((1*#GraphWPad#)+(0*#GraphW#))
+Y=((1*#GraphHPad#)+(0*#GraphH#))
+
+[CPU1GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((2*#GraphWPad#)+(1*#GraphW#))
+Y=((1*#GraphHPad#)+(0*#GraphH#))
+
+[CPU2GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((3*#GraphWPad#)+(2*#GraphW#))
+Y=((1*#GraphHPad#)+(0*#GraphH#))
+
+[CPU3GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((4*#GraphWPad#)+(3*#GraphW#))
+Y=((1*#GraphHPad#)+(0*#GraphH#))
+
+[CPU4GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((5*#GraphWPad#)+(4*#GraphW#))
+Y=((1*#GraphHPad#)+(0*#GraphH#))
+
+[CPU5GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((6*#GraphWPad#)+(5*#GraphW#))
+Y=((1*#GraphHPad#)+(0*#GraphH#))
+
+[CPU6GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((1*#GraphWPad#)+(0*#GraphW#))
+Y=((2*#GraphHPad#)+(1*#GraphH#))
+
+[CPU7GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((2*#GraphWPad#)+(1*#GraphW#))
+Y=((2*#GraphHPad#)+(1*#GraphH#))
+
+[CPU8GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((3*#GraphWPad#)+(2*#GraphW#))
+Y=((2*#GraphHPad#)+(1*#GraphH#))
+
+[CPU9GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((4*#GraphWPad#)+(3*#GraphW#))
+Y=((2*#GraphHPad#)+(1*#GraphH#))
+
+[CPU10GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((5*#GraphWPad#)+(4*#GraphW#))
+Y=((2*#GraphHPad#)+(1*#GraphH#))
+
+[CPU11GraphWrapper]
+Meter=Shape
+; Rounded corner
+Shape=#ShapeValue#
+X=((6*#GraphWPad#)+(5*#GraphW#))
+Y=((2*#GraphHPad#)+(1*#GraphH#))
+
+[CPU12GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((1*#GraphWPad#)+(0*#GraphW#))
+Y=((3*#GraphHPad#)+(2*#GraphH#))
+
+[CPU13GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((2*#GraphWPad#)+(1*#GraphW#))
+Y=((3*#GraphHPad#)+(2*#GraphH#))
+
+[CPU14GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((3*#GraphWPad#)+(2*#GraphW#))
+Y=((3*#GraphHPad#)+(2*#GraphH#))
+
+[CPU15GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((4*#GraphWPad#)+(3*#GraphW#))
+Y=((3*#GraphHPad#)+(2*#GraphH#))
+
+[CPU16GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((5*#GraphWPad#)+(4*#GraphW#))
+Y=((3*#GraphHPad#)+(2*#GraphH#))
+
+[CPU17GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((6*#GraphWPad#)+(5*#GraphW#))
+Y=((3*#GraphHPad#)+(2*#GraphH#))
+
+[CPU18GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((1*#GraphWPad#)+(0*#GraphW#))
+Y=((4*#GraphHPad#)+(3*#GraphH#))
+
+[CPU19GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((2*#GraphWPad#)+(1*#GraphW#))
+Y=((4*#GraphHPad#)+(3*#GraphH#))
+
+[CPU20GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((3*#GraphWPad#)+(2*#GraphW#))
+Y=((4*#GraphHPad#)+(3*#GraphH#))
+
+[CPU21GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((4*#GraphWPad#)+(3*#GraphW#))
+Y=((4*#GraphHPad#)+(3*#GraphH#))
+
+[CPU22GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((5*#GraphWPad#)+(4*#GraphW#))
+Y=((4*#GraphHPad#)+(3*#GraphH#))
+
+[CPU23GraphWrapper]
+Meter=Shape
+Shape=#ShapeValue#
+X=((6*#GraphWPad#)+(5*#GraphW#))
+Y=((4*#GraphHPad#)+(3*#GraphH#))


### PR DESCRIPTION
As title suggests.

What this commit does is adding a container for each `[CPU*Graph]` so that it can have rounded corners. If one does not like rounded corners, simply change the corner radius values to `0` in the `ShapeValue` variable, under `[Variables]` section.

![image](https://github.com/QinnShou/RM-PerCoreGraph/assets/19569343/2d7d926d-6656-42a0-9f65-de0aa40fc920)
